### PR TITLE
WIP: feat: Add workflow to automatically upload UDM to DAFNI

### DIFF
--- a/.github/workflows/uploadToDAFNI.yml
+++ b/.github/workflows/uploadToDAFNI.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
     -
       name: Docker Build
-        run: docker build -t udm-dafni .
+      run: docker build -t udm-dafni .
     -
       name: Compress docker image
       run: |

--- a/.github/workflows/uploadToDAFNI.yml
+++ b/.github/workflows/uploadToDAFNI.yml
@@ -1,11 +1,10 @@
 name: Upload to dafni
 
 on:
-  push:
-    branches:
-      - main
-      - rose/add-dafni-upload-workflow
+  release:
+   types: [published]
 
+   
 jobs:
   publish-udm:
     name: Publish UDM to DAFNI
@@ -22,13 +21,16 @@ jobs:
       run: |
         docker save udm-dafni:latest |
         gzip > udm-dafni.tar.gz
+    - 
+      name: Set tag as env
+      run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     -
       name: Upload To DAFNI
       uses: dafnifacility/dafni-model-uploader@v1.4
       with:
         definition-path: './model_definition.yaml'
         image-path: './udm-dafni.tar.gz'
-        username: 'model-uploader'
+        username: ${{ secrets.DAFNI_SERVICE_ACCOUNT_USERNAME }}
         password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
-        version-message: "Uploaded from GitHub workflow"
+        version-message: ${{ env.TAG }}
         parent-model: "9a5857c0-808d-4328-ad4a-bd27b4240bb6"

--- a/.github/workflows/uploadToDAFNI.yml
+++ b/.github/workflows/uploadToDAFNI.yml
@@ -20,8 +20,8 @@ jobs:
     -
       name: Compress docker image
       run: |
-        docker save -o udm-dafni.tar udm-dafni
-        gzip udm-dafni.tar
+        docker save udm-dafni:latest |
+        gzip > udm-dafni.tar.gz
     -
       name: Upload To DAFNI
       uses: dafnifacility/dafni-model-uploader@v1.4

--- a/.github/workflows/uploadToDAFNI.yml
+++ b/.github/workflows/uploadToDAFNI.yml
@@ -1,0 +1,33 @@
+name: Upload to dafni
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-simple-example-image:
+    name: Publish Simple Example Image
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout code
+      uses: actions/checkout@v2
+    -
+      name: Docker Build
+        run: docker build -t udm-dafni .
+    -
+      name: Compress docker image
+      run: |
+        docker save -o udm-dafni.tar udm-dafni
+        gzip udm-dafni.tar
+    -
+      name: Upload To DAFNI
+      uses: dafnifacility/dafni-model-uploader@v1.4
+      with:
+        definition-path: './model_definition.yaml'
+        image-path: './udm-dafni.tar.gz'
+        username: 'model-uploader'
+        password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
+        version-message: "Uploaded from GitHub workflow"
+        parent-model: "9a5857c0-808d-4328-ad4a-bd27b4240bb6"

--- a/.github/workflows/uploadToDAFNI.yml
+++ b/.github/workflows/uploadToDAFNI.yml
@@ -7,8 +7,8 @@ on:
       - rose/add-dafni-upload-workflow
 
 jobs:
-  publish-simple-example-image:
-    name: Publish Simple Example Image
+  publish-udm:
+    name: Publish UDM to DAFNI
     runs-on: ubuntu-latest
     steps:
     -

--- a/.github/workflows/uploadToDAFNI.yml
+++ b/.github/workflows/uploadToDAFNI.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rose/add-dafni-upload-workflow
 
 jobs:
   publish-simple-example-image:


### PR DESCRIPTION
I've added a Workflow to automatically upload the UDM model to DAFNI currently on a push to main or this branch (which is just for testing). It doesn't currently run because it requires a password for a DAFNI account, I've been using an account I created for testing "model-uploader" but it would probably be better for a different account to be used.

I also don't have permissions add the secret needed by the Workflow so when the decision has been made on what account to use could you let me know the username (so I can update the Workflow) and also could whoever has permissions add the secret using the following name `DAFNI_SERVICE_ACCOUNT_PASSWORD` or alternatively a different name and I can update the Workflow with whichever name is preferred.